### PR TITLE
Remove "rm /usr/local/bin/gfortran"

### DIFF
--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -46,7 +46,6 @@ runs:
       # if: inputs.requiresJAGS && runner.os == 'macOS'
       run: |
         if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'macOS' ]; then
-          rm '/usr/local/bin/gfortran'
           brew install jags
         fi
       shell: bash


### PR DESCRIPTION
Redundant after https://github.com/r-lib/actions/commit/c32e5079b781c315b2398feede7dd819328d779e
Both jaspLearnBayes and [jaspJags](https://github.com/TimKDJ/jaspJags/runs/1777040192?check_suite_focus=true) seem to run fine without it.