### PR TITLE
update unit tests for R4 and new jasp-required-files structure

### DIFF
--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -56,5 +56,4 @@ runs:
         install.packages("ragg")
         remotes::install_github("jasp-stats/jaspTools")
         jaspTools::setupJaspTools()
-        remotes::update_packages(upgrade = "always")
       shell: Rscript {0}

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Clone jasp-required-files on windows
       run: |
-        if [ "${{ inputs.requiresJAGS }}" = 'true' && "${{ runner.os }}" = 'Windows' ]; then
+        if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
           branch='Windows'
           echo "branch=$branch"
           git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -23,24 +23,15 @@ runs:
         fi
       shell: bash
 
-    - name: Clone jasp-required-files
+    - name: Clone jasp-required-files on windows
       run: |
-        if [ "${{ runner.os }}" = 'macOS' ]; then
-          branch='MacOS-Original'
-        else
+        if [ "${{ inputs.requiresJAGS }}" = 'true' && "${{ runner.os }}" = 'Windows' ]; then
           branch='Windows'
+          echo "branch=$branch"
+          git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
         fi
-        echo "branch=$branch"
-        git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
       working-directory: ..
       shell: bash
-
-    - name: Set R library path
-      run: |
-        libPath <- if (.Platform$OS.type == "windows") "/R/library" else "/Frameworks/R.framework/Versions/3.6/Resources/library/"
-        path <- normalizePath(file.path("..", "pkgs", libPath), winslash = "/")
-        cat("\n.libPaths(c('", path, "', .libPaths()))\n", file = "~/.Rprofile", sep = "", append = TRUE)
-      shell: Rscript {0}
 
     - name: Install JAGS on macOS
       # if: inputs.requiresJAGS && runner.os == 'macOS'
@@ -65,5 +56,5 @@ runs:
         install.packages("ragg")
         remotes::install_github("jasp-stats/jaspTools")
         jaspTools::setupJaspTools()
+        remotes::update_packages(upgrade = "always")
       shell: Rscript {0}
-


### PR DESCRIPTION
logs of this in action are here: https://github.com/vandenman/jaspJags/runs/2419541236?check_suite_focus=true

the tests in those logs fail (which is expected) but the installation succeeded. hexbin is missing because it's not listed in the dependencies (although it should be listed). 

This makes jasp-required-files completely obsolete for macOS. On Windows, we only need it because that's where JAGS lives and there is no easy way to install it differently (though I'm looking at alternatives).

This means that all packages are up to date. We might need to adjust that if people specify particular versions in the DESCRIPTION. For that, we should probably do `jaspBase::installModule(path_to_module)` so that we do the exact same thing as in JASP.

this also allows us to run unit tests on Ubuntu, as we only need to install JAGS if needed (but that's for another time).