### PR TITLE
Avoid compiling R pkgs on mac and windows

### DIFF
--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -77,6 +77,10 @@ runs:
 
     - name: Setup jaspTools
       run: |
+        if ("${{ runner.os }}" != "Linux") {
+          # don't try to install new pkgs versions from source (which often requires additional system dependencies which, when missing, lead to errors, e.g., ragg).
+          options(install.packages.compile.from.source = FALSE)
+        }
         install.packages("remotes")
         install.packages("ragg")
         remotes::install_github("jasp-stats/jaspTools")

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -79,7 +79,7 @@ runs:
       run: |
         if ("${{ runner.os }}" != "Linux") {
           # don't try to install new pkgs versions from source (which often requires additional system dependencies which, when missing, lead to errors, e.g., ragg).
-          options(install.packages.compile.from.source = FALSE)
+          options(install.packages.compile.from.source = "never")
         }
         install.packages("remotes")
         install.packages("ragg")


### PR DESCRIPTION
So I wanted to try this out, but it looks like there are already binaries again for macOS. If this doesn't work we can also try `options(pkgType = "binary")`, although I think that will also binary packages over source packages even when there is no C code in the source packages.