### PR TITLE
Define QMFILE for modules other than jasp-desktop

### DIFF
--- a/translations/generateLanguageFiles.sh
+++ b/translations/generateLanguageFiles.sh
@@ -53,6 +53,7 @@ do
 			QMFILE=${moduleName}/Resources/translations/jaspDesktop-${languageCode}.qm
 		else
 			LANGUAGEFILE=${moduleName}/po/QML-${languageCode}.po
+			QMFILE=${moduleName}/inst/qml/translations/jaspDesktop-${languageCode}.qm
 		fi
 
 		do_lupdate   $moduleName $LANGUAGEFILE

--- a/translations/generateLanguageFiles.sh
+++ b/translations/generateLanguageFiles.sh
@@ -53,7 +53,7 @@ do
 			QMFILE=${moduleName}/Resources/translations/jaspDesktop-${languageCode}.qm
 		else
 			LANGUAGEFILE=${moduleName}/po/QML-${languageCode}.po
-			QMFILE=${moduleName}/inst/qml/translations/jaspDesktop-${languageCode}.qm
+			QMFILE=${moduleName}/inst/qml/translations/${moduleName}-${languageCode}.qm
 		fi
 
 		do_lupdate   $moduleName $LANGUAGEFILE


### PR DESCRIPTION
The `.qm` files for most modules should be updated as well; this could (at least partially) fix issue https://github.com/jasp-stats/jasp-issues/issues/1340