### PR TITLE
set JAGS_ROOT environment variable on windows

### DIFF
--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -38,12 +38,12 @@ runs:
       working-directory: ..
       shell: bash
 
-      - name: Test JAGS_ROOT on windows
-        run: |
-          if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
-            echo $JAGS_ROOT
-          fi
-        shell: bash
+    - name: Test JAGS env variable on windows
+      run: |
+        if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
+          echo $JAGS_ROOT
+        fi
+      shell: bash
 
     - name: Install JAGS on macOS
       # if: inputs.requiresJAGS && runner.os == 'macOS'

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -31,8 +31,9 @@ runs:
           git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
 
           # set JAGS_ROOT environment variable required for compiling JAGS_MODULES
-          echo $(readlink -f ../pkgs/64/JAGS)
-          echo "JAGS_ROOT=$(readlink -f ../pkgs/64/JAGS)" >> $GITHUB_ENV
+          echo "'$(readlink -f pkgs/64/JAGS)'"
+          echo $(readlink -f pkgs/64/JAGS)
+          echo "JAGS_ROOT=$(readlink -f pkgs/64/JAGS)" >> $GITHUB_ENV
           echo $JAGS_ROOT
         fi
       working-directory: ..
@@ -41,6 +42,7 @@ runs:
     - name: Test JAGS env variable on windows
       run: |
         if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
+          echo "testing JAGS_ROOT location:"
           echo $JAGS_ROOT
         fi
       shell: bash

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -31,20 +31,11 @@ runs:
           git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
 
           # set JAGS_ROOT environment variable required for compiling JAGS_MODULES
-          echo "'$(readlink -f pkgs/64/JAGS)'"
+          echo '$(readlink -f pkgs/64/JAGS)'
           echo $(readlink -f pkgs/64/JAGS)
           echo "JAGS_ROOT=$(readlink -f pkgs/64/JAGS)" >> $GITHUB_ENV
-          echo $JAGS_ROOT
         fi
       working-directory: ..
-      shell: bash
-
-    - name: Test JAGS env variable on windows
-      run: |
-        if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
-          echo "testing JAGS_ROOT location:"
-          echo $JAGS_ROOT
-        fi
       shell: bash
 
     - name: Install JAGS on macOS

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -23,14 +23,13 @@ runs:
         fi
       shell: bash
 
-    - name: Clone jasp-required-files on windows
+    - name: Install JAGS on Windows
       run: |
         if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
-          branch='Windows'
-          echo "branch=$branch"
-          git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
+          curl -o wjags.exe --url https://deac-fra.dl.sourceforge.net/project/mcmc-jags/JAGS/4.x/Windows/JAGS-4.3.0.exe
+          ./wjags.exe
+          rm wjags.exe
         fi
-      working-directory: ..
       shell: bash
 
     - name: Install JAGS on macOS

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -31,9 +31,9 @@ runs:
           git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
 
           # set JAGS_ROOT environment variable required for compiling JAGS_MODULES
-          echo '$(readlink -f pkgs/64/JAGS)'
-          echo $(readlink -f pkgs/64/JAGS)
-          echo "JAGS_ROOT=$(readlink -f pkgs/64/JAGS)" >> $GITHUB_ENV
+          jags_root=$(readlink -f pkgs/64/JAGS)
+          echo "jags_root = $jags_root"
+          echo "JAGS_ROOT=$jags_root" >> $GITHUB_ENV
         fi
       working-directory: ..
       shell: bash

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -23,13 +23,14 @@ runs:
         fi
       shell: bash
 
-    - name: Install JAGS on Windows
+    - name: Clone jasp-required-files on windows
       run: |
         if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
-          curl -o wjags.exe --url https://deac-fra.dl.sourceforge.net/project/mcmc-jags/JAGS/4.x/Windows/JAGS-4.3.0.exe
-          ./wjags.exe
-          rm wjags.exe
+          branch='Windows'
+          echo "branch=$branch"
+          git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
         fi
+      working-directory: ..
       shell: bash
 
     - name: Install JAGS on macOS

--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -29,9 +29,21 @@ runs:
           branch='Windows'
           echo "branch=$branch"
           git clone --branch=$branch https://github.com/jasp-stats/jasp-required-files.git pkgs
+
+          # set JAGS_ROOT environment variable required for compiling JAGS_MODULES
+          echo $(readlink -f ../pkgs/64/JAGS)
+          echo "JAGS_ROOT=$(readlink -f ../pkgs/64/JAGS)" >> $GITHUB_ENV
+          echo $JAGS_ROOT
         fi
       working-directory: ..
       shell: bash
+
+      - name: Test JAGS_ROOT on windows
+        run: |
+          if [ "${{ inputs.requiresJAGS }}" = 'true' ] && [ "${{ runner.os }}" = 'Windows' ]; then
+            echo $JAGS_ROOT
+          fi
+        shell: bash
 
     - name: Install JAGS on macOS
       # if: inputs.requiresJAGS && runner.os == 'macOS'


### PR DESCRIPTION
Otherwise, custom JAGS modules cannot be compiled. This should also happen in jasp itself, see https://github.com/jasp-stats/INTERNAL-jasp/issues/1459 but this is only an issue when people would install a module (rather than using the binaries we provide).