### PR TITLE
Never compile R packages, except on Linux

### DIFF
--- a/setup-test-env/action.yml
+++ b/setup-test-env/action.yml
@@ -80,12 +80,16 @@ runs:
         }
       shell: Rscript {0}
 
-    - name: Setup jaspTools
+    - name: Set environment variable to never compile packages on Windows and macOS
       run: |
         if ("${{ runner.os }}" != "Linux") {
           # don't try to install new pkgs versions from source (which often requires additional system dependencies which, when missing, lead to errors, e.g., ragg).
-          options(install.packages.compile.from.source = "never")
+          cat("\noptions(install.packages.compile.from.source = \"never\")\n", file = "~/.Rprofile", sep = "", append = TRUE)
         }
+      shell: Rscript {0}
+
+    - name: Setup jaspTools
+      run: |
         install.packages("remotes")
         install.packages("ragg")
         remotes::install_github("jasp-stats/jaspTools")


### PR DESCRIPTION
Fixes the issues where R tries to compile packages on Windows and macOS.

Example:

https://github.com/vandenman/Reliability/runs/4223945333?check_suite_focus=true

from the Windows log:
![image](https://user-images.githubusercontent.com/21319932/141977690-476808bc-ff67-4a27-ac92-2eb0bcd79183.png)

