### PR TITLE
Run unit tests with `4.2.0` instead of `devel`

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ['4.1.3', 'devel']
+        r: ['4.1.3', '4.2.0']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     env:
@@ -56,6 +56,7 @@ jobs:
       VDIFFR_RUN_TESTS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       _R_CHECK_LENGTH_1_CONDITION_: TRUE #deprecated from R 4.2.0
+      _R_CHECK_MATRIX_DATA_: TRUE # only works from R 4.2.0 onwards
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
See title. This should make the tests run a lot smoother since we no longer have to compile from source on macOS and windows (which may introduce annoying installation failures due to missing system dependencies, or things like `brew update` failing.)

Also sets `_R_CHECK_MATRIX_DATA_`, which turns some specific warnings into errors, see https://developer.r-project.org/blosxom.cgi/R-devel/NEWS/2022/03/27#n2022-03-27