### PR TITLE
Run R unittests on R-4.2.1 instead of R-4.2.0

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ['4.1.3', '4.2.0']
+        r: ['4.1.3', '4.2.1']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     env:


### PR DESCRIPTION
Per https://github.com/jasp-stats/INTERNAL-jasp/issues/1886, we should now test on 4.2.1 instead of 4.2.0 since we'll probably skip 4.2.0.