### PR TITLE
using ` r-lib/actions/setup-r-dependencies@v2`

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -135,14 +135,6 @@ jobs:
         run: sudo apt install jags
         shell: bash
 
-      - name: Set repository for binaries on Linux
-        if: runner.os == 'Linux'
-        run : |
-          # repos from https://github.com/r-lib/actions/tree/master/examples#standard-ci-workflow
-          cat('\noptions("repos" = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")\n', 
-              file = "~/.Rprofile", sep = "", append = TRUE)
-        shell: Rscript {0}
-
       - name: Set environment variable to never compile packages on Windows and macOS
         if: runner.os != 'Linux' && matrix.r != 'devel'
         run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -125,6 +125,11 @@ jobs:
           sudo apt install libharfbuzz-dev libfribidi-dev libgit2-dev libcurl4-openssl-dev
         shell: bash
 
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: check
+          cache-version: 2
+
       - name: Install JAGS on Linux
         if: runner.os == 'Linux' && inputs.needs_JAGS
         run: sudo apt install jags


### PR DESCRIPTION
Fix https://github.com/jasp-stats/INTERNAL-jasp/issues/2192

This will fix a recent issue with failing unit tests on Linux.

- Now we also using [cache](https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28) for unit tests, the first run may produce unexpected interruptions and disappears after re-running,  this may speed up all runs in the next.

- Not really sure if we still need install for binaries on Linux from RSPM repository.Because most of the dependencies are already installed, and preferably from the binary.