### PR TITLE
Adjust step for r-dependencies installation

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -125,8 +125,19 @@ jobs:
           sudo apt install libharfbuzz-dev libfribidi-dev libgit2-dev libcurl4-openssl-dev
         shell: bash
 
+      - name: Set environment variable to never compile packages on Windows and macOS
+        if: runner.os != 'Linux' && matrix.r != 'devel'
+        run: |
+          # don't try to install new pkgs versions from source (which often requires additional system dependencies which, when missing, lead to errors, e.g., ragg).
+          cat("\noptions(install.packages.compile.from.source = \"never\")\n", file = "~/.Rprofile", sep = "", append = TRUE)
+        shell: Rscript {0}
+        
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          extra-packages: |
+            any::rcmdcheck
+            github::jasp-stats/jaspTools
+            cran::igraph
           needs: check
           cache-version: 2
 
@@ -135,17 +146,8 @@ jobs:
         run: sudo apt install jags
         shell: bash
 
-      - name: Set environment variable to never compile packages on Windows and macOS
-        if: runner.os != 'Linux' && matrix.r != 'devel'
-        run: |
-          # don't try to install new pkgs versions from source (which often requires additional system dependencies which, when missing, lead to errors, e.g., ragg).
-          cat("\noptions(install.packages.compile.from.source = \"never\")\n", file = "~/.Rprofile", sep = "", append = TRUE)
-        shell: Rscript {0}
-
       - name: Setup jaspTools
         run: |
-          install.packages(c("remotes", "ragg"))
-          remotes::install_github("jasp-stats/jaspTools")
           jaspTools::setupJaspTools()
         shell: Rscript {0}
 


### PR DESCRIPTION
- Adjust more reasonable order of setup steps on macOS and Windows
- Install jaspTools by r-dependencies, avoid repeated installation of some packages (remotes, ragg), because repeated installation of ragg will indeed bring unexpected [errors](https://github.com/jasp-stats/jaspAnova/actions/runs/3740403112/jobs/6348740216#step:14:236)

See test [branch ](https://github.com/shun2wang/jasp-actions/commits/try_unittest_fix/.github/workflows/unittests.yml) and run [logs](https://github.com/shun2wang/jaspAnova/actions/runs/3747425059/jobs/6378319229) for more details.