### PR TITLE
Including .in file in Qt translation and also bump tools version

### DIFF
--- a/translations/action.yml
+++ b/translations/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - uses: r-lib/actions/setup-r@v2
       with:
-        r-version: "4.2.1"
+        r-version: "4.2.2"
  
     - name: Install wlc and gettext
       run: sudo apt -y install wlc gettext
@@ -24,9 +24,9 @@ runs:
       shell: bash
       
     - name: install Qt6
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
-        version: 6.2.3
+        version: 6.4.*
         
     - name: generate Language Files
       run: |

--- a/translations/generateLanguageFiles.sh
+++ b/translations/generateLanguageFiles.sh
@@ -11,7 +11,7 @@ create_file_if_it_doesnt_exist() {
 	fi
 }
 
-do_lupdate()	{	lupdate -locations none -extensions cpp,qml -recursive $1 -ts $2;	}
+do_lupdate()	{	lupdate -locations none -extensions cpp,qml,in -recursive $1 -ts $2;	}
 do_msgattrib()	{	msgattrib --no-obsolete --no-location ${1} -o $1;	}
 
 # in case people try this at home


### PR DESCRIPTION
- The .in file was not including in lupdate extensions, so some strings not into POT file (e.g. [here](https://github.com/jasp-stats/jasp-desktop/blob/fc1f1172f5d15c81baf563ab049ac0e4dd26f482/Desktop/gui/preferencesmodel.cpp.in#L530) ) and some JASP pop-up window, you can see success case from my [branch](https://github.com/shun2wang/jasp-desktop/commit/2a70d2fcf073a0ca975795d0d857e2335d32b0fd).
- Now we also using new `jurplel/install-qt-action@v3` action to install Qt 6 series stable.