### PR TITLE
More exact strings pick up

### DIFF
--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -10,7 +10,7 @@ cli_h1("Check R translations:")
 rPotData <- potools::get_message_data(dir = ".", verbose = TRUE)
 
 # Get wrong usage of gettext from .R
-rErrorCalls <- subset(rPotData, grepl(pattern="gettext\\(\"\"\\)", call), select = c("file", "call", "line_number"))
+rErrorCalls <- subset(rPotData, grepl(pattern="gettext(|f)\\(\"\"\\)", call), select = c("file", "call", "line_number"))
           
 if (nrow(rErrorCalls) > 0) {
   checkStatus <- c(checkStatus, 1)

--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -10,7 +10,7 @@ cli_h1("Check R translations:")
 rPotData <- potools::get_message_data(dir = ".", verbose = TRUE)
 
 # Get wrong usage of gettext from .R
-rErrorCalls <- subset(rPotData, grepl(pattern="gettext(|f)\\(\"\"\\)", call), select = c("file", "call", "line_number"))
+rErrorCalls <- subset(rPotData, grepl(pattern="gettext(|f)\\(['\"]['\"]\\)", call), select = c("file", "call", "line_number"))
           
 if (nrow(rErrorCalls) > 0) {
   checkStatus <- c(checkStatus, 1)

--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -10,7 +10,7 @@ cli_h1("Check R translations:")
 rPotData <- potools::get_message_data(dir = ".", verbose = TRUE)
 
 # Get wrong usage of gettext from .R
-rErrorCalls <- subset(rPotData, rPotData$msgid == "", select = c("file", "call", "line_number"))
+rErrorCalls <- subset(rPotData, grepl(pattern="gettext\\(\"\"\\)", call), select = c("file", "call", "line_number"))
           
 if (nrow(rErrorCalls) > 0) {
   checkStatus <- c(checkStatus, 1)
@@ -41,7 +41,7 @@ if (length(qmlFiles) == 0) {
       Call_code        = readL[,1], 
       Line_number      = 1:nrow(readL),
       Translation_call = grepl(pattern="qsTr(|Id|anslate)\\(\".*\"\\)", readL[,1]),
-      Empty_call       = grepl(pattern="qsTr(|Id|anslate)\\(\"*\"\\)", readL[,1]))
+      Empty_call       = grepl(pattern="qsTr(|Id|anslate)\\(\"\"\\)", readL[,1]))
 
     qmlSrcData <- rbind(qmlSrcData, tempData)
   }


### PR DESCRIPTION
Fix extra string extraction cause actions failing such as [here](https://github.com/jasp-stats/jaspMetaAnalysis/actions/runs/4500186889/jobs/7918986863#step:6:23), and this seems a bug from `potools`.

A demo test on my branch at [here](https://github.com/shun2wang/jaspMetaAnalysis/actions/runs/4500917838)

Note: If you want to have a test for this, you may simple to change `i18nCheck.yml` here on your test branch:

`curl -o $PWD/i18nCheck.R https://raw.githubusercontent.com/jasp-stats/jasp-actions/master/translations/i18nCheck.R`

to
`curl -o $PWD/i18nCheck.R https://raw.githubusercontent.com/shun2wang/jasp-actions/fixi18n/translations/i18nCheck.R`