### PR TITLE
Fix homebrew failing on macOS

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Install system dependencies on macOS
         if: runner.os == 'macOS'
         run: |
+          # see https://github.com/orgs/Homebrew/discussions/4612
+          unset HOMEBREW_NO_INSTALL_FROM_API
           brew update
           # Caught by https://github.com/actions/runner-images/issues/6817
           brew link --overwrite python@3.10


### PR DESCRIPTION
See https://github.com/orgs/Homebrew/discussions/4612

and this bug causes the unit testing action fail randomly to setup. such as [here](https://github.com/jasp-stats/jaspDescriptives/actions/runs/5475362578/jobs/9971364021).

The reason for us fixed it was the fact that the setup-r workflow would already setup homebrew but use this api, in fact it was unnecessary:
```
==> You have set:
  HOMEBREW_NO_AUTO_UPDATE
  HOMEBREW_NO_INSTALL_FROM_API
but we have dramatically sped up and fixed many bugs in the way we do Homebrew updates since.
Please consider unsetting these and tweaking the values based on the new behaviour.
```
 so we could just set it to empty.