### PR TITLE
Fix unittest failing on dependencies handling

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -142,6 +142,7 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             github::jasp-stats/jaspTools
+            vdiffr@1.0.5
           needs: check
           cache-version: 3
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -125,8 +125,9 @@ jobs:
           # ragg                                          requires libharfbuzz-dev libfribidi-dev 
           # credentials   (dependency of usethis)         requires libgit2-dev
           # curl          (dependency of usethis)         requires libcurl4-openssl-dev
+          # libicu   (dependency of igraph or stringi...) requires libicu libicu-dev
 
-          sudo apt install libharfbuzz-dev libfribidi-dev libgit2-dev libcurl4-openssl-dev
+          sudo apt install libharfbuzz-dev libfribidi-dev libgit2-dev libcurl4-openssl-dev libicu*
         shell: bash
 
       - name: Set environment variable to never compile packages on Windows and macOS

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -143,7 +143,7 @@ jobs:
             any::rcmdcheck
             github::jasp-stats/jaspTools
           needs: check
-          cache-version: 2
+          cache-version: 3
 
       - name: Install JAGS on Linux
         if: runner.os == 'Linux' && inputs.needs_JAGS

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install JAGS on macOS
         if: runner.os == 'macOS' && inputs.needs_JAGS
         run: |
-          rm '/usr/local/bin/gfortran'
+          # rm '/usr/local/bin/gfortran'
           brew install jags
         shell: bash
 


### PR DESCRIPTION
- macOS: `gfortran` things changed by rtools43 so it's not needs handling manually anymore.
- Linux: `libicu` will failing on some r packages install.
- Temporary pin vdiffr to 1.0.5 due to https://github.com/r-lib/vdiffr/issues/137 we can remove this after 1.0.7 released on CRAN.
- General: for every time action update we can try bump `cache-version`.

test runner see: https://github.com/shun2wang/jaspMetaAnalysis/actions/workflows/unittests.yml