### PR TITLE
install libarchive on macOS

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -74,6 +74,7 @@ jobs:
           # Caught by https://github.com/actions/runner-images/issues/6817
           brew link --overwrite python@3.10
           brew install --cask xquartz
+          brew install libarchive
         shell: bash
         
       - name: Install system dependencies on macOS specific to R devel


### PR DESCRIPTION
Fix install archive package failing on macOS. see log: https://github.com/shun2wang/jaspMixedModels/actions/runs/6543221761/job/17767455540