### PR TITLE
bump r version to 4.3.2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ['4.3.1']
+        r: ['4.3.2']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     env:
@@ -59,7 +59,7 @@ jobs:
       _R_CHECK_MATRIX_DATA_: TRUE # only works from R 4.2.0 onwards
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
as requested by @juliuspfadt.

@JorisGoosen is the R version we're using already "officially" 4.3.2?