### PR TITLE
remove brew link python310 on macOS

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -71,8 +71,6 @@ jobs:
           # see https://github.com/orgs/Homebrew/discussions/4612
           unset HOMEBREW_NO_INSTALL_FROM_API
           brew update
-          # Caught by https://github.com/actions/runner-images/issues/6817
-          brew link --overwrite python@3.10
           brew install --cask xquartz
           brew install libarchive
         shell: bash


### PR DESCRIPTION
I removed ` brew link --overwrite python@3.10` things due to it's broken action on macOS now. and seems it's unnecessary now.