### PR TITLE
just get error static rather than during .mo compiling

### DIFF
--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -35,7 +35,7 @@ rErrorCalls <- subset(rPotData,
                      select = c("file", "call", "line_number"))
 
 # Get po/mo compiling error of R
-e <- capture.output(tools::update_pkg_po("."))
+e <- capture.output(tools::checkPoFiles("."))
 rPoError <- as.data.frame(matrix(e, ncol=5, byrow=TRUE))[1:4]
 colnames(rPoError) <- c("Error_Location", "Error_Type", "Original_Gettext", "Translated_text")
 


### PR DESCRIPTION
`update_pkg_po` -> `checkPoFiles`

for example this action https://github.com/jasp-stats/jaspSem/actions/runs/8064062809 was failed because this stage will generate duplicate `msgid` when trying to compile English language files(these duplicate strings will be removed in subsequent stages) so this error will cause the process to fail. Now we just check for errors from the resulting po. Not entirely sure if doing this will cause us to miss some errors in the compilation process.

@boutinb what do you think, I see you have manually removed some duplicate strings from `.po` files.