### PR TITLE
translation: fix merge duplicate msg issue

### DIFF
--- a/translations/translate.R
+++ b/translations/translate.R
@@ -141,7 +141,7 @@ jaspXgettext2pot <-
                  '"Language-Team: LANGUAGE <LL@li.org>\\n"',
                  '"Language: \\n"',
                  '"MIME-Version: 1.0\\n"',
-                 '"Content-Type: text/plain; charset=CHARSET\\n"',
+                 '"Content-Type: text/plain; charset=UTF-8\\n"',
                  '"Content-Transfer-Encoding: 8bit\\n"',
                  if (length(un)) '"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\\n"'))
     for(e in msgid)
@@ -364,4 +364,4 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
 }
 #  End of copied code from translations.R
 
-try(jasp_update_pkg_po(pkgdir = rootfolder, verbose = TRUE, mergeOpts = "--verbose"))
+try(jasp_update_pkg_po(pkgdir = rootfolder, verbose = TRUE))

--- a/translations/translate.R
+++ b/translations/translate.R
@@ -165,6 +165,8 @@ jaspXgettext2pot <-
 #  Start of copied code from R-SVN File src/library/tools/R/translations.R;
 #  Refactoring update_pkg_po -> jasp_update_pkg_po.
 jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
+                          pot_make = TRUE, mo_make = TRUE,
+                          verbose = getOption("verbose"),
                           mergeOpts = "", # only those *in addition* to --update
                           copyright, bugs)
 {
@@ -188,10 +190,11 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
     desc <- "DESCRIPTION"
     if(file.exists(desc)) {
         desc <- read.dcf(desc, fields = c("Package", "Version"))
-        pkg <- name <- desc[1L]
-        version <- desc[2L]
+        name <- desc[1L]
+        if (is.null(pkg))	pkg <- name
+        if (is.null(version))	version <- desc[2L]
         if (missing(copyright)) copyright <- NULL
-        if (missing(bugs)) bugs <- NULL
+        if (missing(bugs))	bugs <- NULL
         stem <- file.path("inst", "po")
     } else { # A base package
         pkg <- basename(pkgdir)
@@ -205,21 +208,33 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
     ## The interpreter is 'src' for the base package.
     is_base <- (pkg == "base")
     have_src <- paste0(pkg, ".pot") %in% files
+    mergeCmd <- paste("msgmerge", if(is.character(mergeOpts)) paste("--update", mergeOpts))
 
     ## do R-pkg domain first
+  if(pot_make) {
     ofile <- tempfile()
+    if(verbose) cat("Creating pot: .. ")
     jaspXgettext2pot(".", ofile, name, version, bugs)
     potfile <- file.path("po", paste0("R-", pkg, ".pot"))
     if(file.exists(potfile) && same(potfile, ofile)) {
-    } else file.copy(ofile, potfile, overwrite = TRUE)
+        if(verbose) cat("the same() as previous: not copying.\n")
+    } else {
+        if(verbose) cat("copying to potfile", potfile, "\n")
+        file.copy(ofile, potfile, overwrite = TRUE)
+    }
+  } else {
+        if(!file.exists(potfile <- file.path("po", paste0("R-", pkg, ".pot"))))
+            stop(gettextf("file '%s' does not exist", potfile), domain = NA)
+    }
     pofiles <- dir("po", pattern = "R-.*[.]po$", full.names = TRUE)
     pofiles <- pofiles[pofiles != "po/R-en@quot.po"]
     ## .po file might be newer than .mo
     for (f in pofiles) {
         lang <- sub("^R-(.*)[.]po$", "\\1", basename(f))
+        ## Interestingly does *not* update the file dates
+        cmd <- paste(mergeCmd, f, shQuote(potfile))
+        if(verbose) cat("Running cmd", cmd, ":\n") else
         message("  R-", lang, ":", appendLF = FALSE, domain = NA)
-        ## This seems not to update the file dates.
-        cmd <- paste("msgmerge --update", mergeOpts, f, shQuote(potfile))
         if(system(cmd) != 0L) {
             warning("running msgmerge on ", sQuote(f), " failed", domain = NA)
             next
@@ -230,18 +245,20 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
             message("not installing", domain = NA)
             next
         }
+        if(!mo_make) next
         dest <- file.path(stem, lang, "LC_MESSAGES")
         dir.create(dest, FALSE, TRUE)
         dest <- file.path(dest, sprintf("R-%s.mo", pkg))
  #       if(file_test("-ot", f, dest)) next
         cmd <- paste("msgfmt -c --statistics -o", shQuote(dest), shQuote(f))
+        if(verbose) cat("Running cmd", cmd, ":\n")
         if(system(cmd) != 0L)
             warning(sprintf("running msgfmt on %s failed", basename(f)),
                     domain = NA, immediate. = TRUE)
     }
 
     ## do en@quot
-    if (l10n_info()[["UTF-8"]]) {
+    if (l10n_info()[["UTF-8"]] && mo_make) {
         lang <- "en@quot"
         message("  R-", lang, ":", domain = NA)
         # f <- "po/R-en@quot.po"
@@ -251,6 +268,7 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
         dir.create(dest, FALSE, TRUE)
         dest <- file.path(dest, sprintf("R-%s.mo", pkg))
         cmd <- paste("msgfmt -c --statistics -o", shQuote(dest), shQuote(f))
+        if(verbose) cat("Running cmd", cmd, ":\n")
         if(system(cmd) != 0L)
             warning(sprintf("running msgfmt on %s failed", basename(f)),
                     domain = NA, immediate. = TRUE)
@@ -258,6 +276,7 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
 
     if(!(is_base || have_src)) return(invisible())
 
+  if(pot_make) {
     ofile <- tempfile()
     if (!is_base) {
         dom <- pkg
@@ -284,18 +303,26 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
                  sprintf('--msgid-bugs-address="%s"', bugs),
              if(is_base) "-C") # avoid messages about .y
     cmd <- paste(c(cmd, cfiles), collapse=" ")
-    if(system(cmd) != 0L) stop("running jaspXgettext failed", domain = NA)
+    if(verbose) cat("Running cmd", cmd, ":\n")
+    if(system(cmd) != 0L) stop("running xgettext failed", domain = NA)
     setwd(od)
 
     ## compare ofile and po/dom.pot, ignoring dates.
     potfile <- file.path("po", paste0(dom, ".pot"))
     if(!same(potfile, ofile)) file.copy(ofile, potfile, overwrite = TRUE)
+
+  } else { # not pot_make
+        dom <- if(is_base) "R" else pkg
+        if(!file.exists(potfile <- file.path("po", paste0(dom, ".pot"))))
+            stop(gettextf("file '%s' does not exist", potfile), domain = NA)
+    }
     pofiles <- dir("po", pattern = "^[^R].*[.]po$", full.names = TRUE)
     pofiles <- pofiles[pofiles != "po/en@quot.po"]
     for (f in pofiles) {
         lang <- sub("[.]po", "", basename(f))
+        cmd <- paste(mergeCmd, shQuote(f), shQuote(potfile))
+        if(verbose) cat("Running cmd", cmd, ":\n") else
         message("  ", lang, ":", appendLF = FALSE, domain = NA)
-        cmd <- paste("msgmerge --update", mergeOpts, shQuote(f), shQuote(potfile))
         if(system(cmd) != 0L) {
             warning("running msgmerge on ",  f, " failed", domain = NA)
             next
@@ -306,17 +333,19 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
             message("not installing", domain = NA)
             next
         }
+        if(!mo_make) next
         dest <- file.path(stem, lang, "LC_MESSAGES")
         dir.create(dest, FALSE, TRUE)
         dest <- file.path(dest, sprintf("%s.mo", dom))
 #        if(file_test("-ot", f, dest)) next
         cmd <- paste("msgfmt -c --statistics -o", shQuote(dest), shQuote(f))
+        if(verbose) cat("Running cmd", cmd, ":\n")
         if(system(cmd) != 0L)
             warning(sprintf("running msgfmt on %s failed", basename(f)),
                     domain = NA)
     }
     ## do en@quot
-    if (l10n_info()[["UTF-8"]]) {
+    if (l10n_info()[["UTF-8"]] && mo_make) {
         lang <- "en@quot"
         message("  ", lang, ":", domain = NA)
         f <- tempfile()
@@ -325,6 +354,7 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
         dir.create(dest, FALSE, TRUE)
         dest <- file.path(dest, sprintf("%s.mo", dom))
         cmd <- paste("msgfmt -c --statistics -o", shQuote(dest), shQuote(f))
+        if(verbose) cat("Running cmd", cmd, ":\n")
         if(system(cmd) != 0L)
             warning(sprintf("running msgfmt on %s failed", basename(f)),
                     domain = NA)
@@ -334,4 +364,4 @@ jasp_update_pkg_po <- function(pkgdir, pkg = NULL, version = NULL,
 }
 #  End of copied code from translations.R
 
-try(jasp_update_pkg_po(rootfolder))
+try(jasp_update_pkg_po(pkgdir = rootfolder, verbose = TRUE, mergeOpts = "--verbose"))

--- a/translations/translate.R
+++ b/translations/translate.R
@@ -1,6 +1,6 @@
 #  Drop "stop" "warning" "message" "packageStartupMessage" in xgettext.
 #  Modified from R-SVN File src/library/tools/R/xgettext.R and translation.R
-#  Snapshot at UTC+8 2023-05-29 15:00
+#  Snapshot at UTC+8 2024-05-26 18:00
 
 
 if(!exists("rootfolder"))


### PR DESCRIPTION
In some cases, the translation generation workflow will fail inexplicably. This is actually a defect of R tools. I temporarily fixed it with a hack.
so:
```
 '"Content-Type: text/plain; charset=CHARSET\\n"',
```
cannot merge some unicode strings while generate .po file from .pot.
should be
```
 '"Content-Type: text/plain; charset=CHARSET\\n"',
```