### PR TITLE
always run unlock weblate

### DIFF
--- a/translations/action.yml
+++ b/translations/action.yml
@@ -49,5 +49,6 @@ runs:
       shell: bash
       
     - name: Reset and unlock weblate repos
+      if: always()
       run: ${{ github.action_path }}/unlockWeblate.sh
       shell: bash


### PR DESCRIPTION
we was locked first the weblate while merge and push translation, if action failed the unlock action also not run. maybe we should always unlock weblate repo to accept translation works from translator but not wait for us noticed and do it manually.