### PR TITLE
i18n: check for link embedded directly inside translation calls

### DIFF
--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -9,8 +9,8 @@ checkStatus <- c()
 msgErrorCheck <- function(msgData, warningMsg) {
   if (nrow(msgData) > 0) {
     checkStatus <<- c(checkStatus, 1)
-    cli_h2(warningMsg)
-    cli_alert_danger("Please refer to following to resolve them:")
+    cli_h2("Please refer to following to resolve them:")
+    cli_alert_danger(warningMsg)
     print(msgData, row.names = FALSE)
   }
 }
@@ -28,12 +28,14 @@ rEmptyCalls <- subset(rPotData,
                       grepl(pattern = "gettext(|f)\\(['\"]['\"]\\)", call),
                       select = c("file", "call", "line_number"))
 templateMsgError <- subset(rPotData, grepl(pattern = "%\\d\\$", msgid)                                 # match all placeholders like %1$s
-                            & (!grepl(pattern = "%1\\$", msgid) | grepl(pattern = "%[a-zA-Z]", msgid)), # match missing %1$ or %s is present
+                           & (!grepl(pattern = "%1\\$", msgid) | grepl(pattern = "%[a-zA-Z]", msgid)), # match missing %1$ or %s is present
                            select = c("file", "call", "line_number"))
 rErrorCalls <- subset(rPotData,
-                     grepl(pattern = "^gettext\\(.*%.*\\)", call),
-                     select = c("file", "call", "line_number"))
-
+                      grepl(pattern = "^gettext\\(.*%.*\\)", call),
+                      select = c("file", "call", "line_number"))
+rLinkEmbedded <- subset(rPotData,
+                      grepl(pattern = "(http|https)://", call),
+                      select = c("file", "call", "line_number"))
 
 # Get po/mo compiling error of R, We customized the tools::checkPoFiles function
 jaspCheckPoFiles <- function(dir) {
@@ -57,11 +59,12 @@ if (length(e) > 1) {
   colnames(rPoError) <- c("Error_Location", "References", "Error_Type", "Original_Gettext", "Translated_text")
 }
 
-msgErrorCheck(rPoError,         "Some translation errors found in po file")
-msgErrorCheck(rEmptyCalls,      "{nrow(rEmptyCalls)} empty gettext call(s) found")
-msgErrorCheck(placeholderData,  "{nrow(placeholderData)} multiple placeholders without index found")
-msgErrorCheck(templateMsgError, "There are numbering errors with multiple placeholders")
-msgErrorCheck(rErrorCalls,      "Don't use `gettext()` if `%` inside, but use `gettextf()` with `%%` instead")
+msgErrorCheck(rPoError,         "Some translation errors found in po file.")
+msgErrorCheck(rEmptyCalls,      "{nrow(rEmptyCalls)} empty gettext call(s) found.")
+msgErrorCheck(placeholderData,  "{nrow(placeholderData)} multiple placeholders without index found.")
+msgErrorCheck(templateMsgError, "There are numbering errors with multiple placeholders.")
+msgErrorCheck(rErrorCalls,      "Don't use `gettext()` if `%` inside, but use `gettextf()` with `%%` instead.")
+msgErrorCheck(rLinkEmbedded,    "Please don't pass the link directly inside translation call(s).")
 
 if (length(checkStatus) == 0) {
   cli_alert_success("R message check PASSED")
@@ -72,7 +75,7 @@ cli_h1("Check QML translations:")
 qmlFiles <- list.files(path = file.path("inst", "qml"), pattern = "\\.qml", recursive = TRUE, full.names = TRUE)
 
 if (length(qmlFiles) == 0) {
-  cli_alert("No QML file found")
+  cli_alert("No QML file found, maybe it's not a valid JASP module.")
 } else {
   # Generate pot meta data from QML
   qmlSrcData <- data.frame()
@@ -86,19 +89,24 @@ if (length(qmlFiles) == 0) {
       Call_code        = readL[, 1],
       Line_number      = 1:nrow(readL),
       Translation_call = grepl(pattern = "qsTr(|Id|anslate)\\(['\"].*['\"]\\)", readL[, 1]),  # match for qsTr, qsTranslate and qsTrId calls.
-      Empty_call       = grepl(pattern = "qsTr(|Id|anslate)\\((|['\"]['\"])\\)", readL[, 1])  # match for empty qsTr(),qsTr(""),qsTr('') etc.
+      Empty_call       = grepl(pattern = "qsTr(|Id|anslate)\\((|['\"]['\"])\\)", readL[, 1]),  # match for empty qsTr(),qsTr(""),qsTr('') etc.
+      Link_embedded    = grepl(pattern = "(http|https)://", readL[, 1])
     )
     
     qmlSrcData <- rbind(qmlSrcData, tempData)
   }
   
-  qmlErrorCalls <- subset(qmlSrcData, qmlSrcData$Empty_call == 1, select = c(1:3)) 
-}
-
-if (nrow(qmlErrorCalls) == 0) {
-  cli_alert_success("QML message check PASSED")
-} else {
-  msgErrorCheck(qmlErrorCalls, "{nrow(qmlErrorCalls)} empty Qt translate call(s) found")
+  hasEmptyCall  <- qmlSrcData$Empty_call == TRUE
+  hasLink       <- qmlSrcData$Translation_call & qmlSrcData$Link_embedded
+  qmlErrorCalls <- subset(qmlSrcData, hasEmptyCall | hasLink, select = c(1:3))
+  
+  if (nrow(qmlErrorCalls) == 0) {
+    cli_alert_success("QML message check PASSED")
+  } else {
+    if (any(hasEmptyCall))    cli_alert_danger("Please don't pass empty strings inside translation call(s).")
+    if (any(hasLink))         cli_alert_danger("Please use `.arg()` to pass the link instead of pass it directly inside call(s).")
+    msgErrorCheck(qmlErrorCalls, "{nrow(qmlErrorCalls)} not recommended Qt translate call(s) found.")
+  }
 }
 
 if (length(checkStatus) > 0) {

--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -41,7 +41,6 @@ rLinkEmbedded <- subset(rPotData,
 jaspCheckPoFiles <- function(dir) {
   files <- list.files(path = dir, pattern = "^R-.*[.]po$",
                       full.names = TRUE, recursive = TRUE)
-  #files <- files[!endsWith(files, "ta.po")]
   result <- matrix(character(), ncol = 5L, nrow = 0L)
   for (f in files) {
     errs <- tools::checkPoFile(f, strictPlural = startsWith(basename(f), "R-"))


### PR DESCRIPTION
Checking links in translation messages not only prevents links from being accidentally broken, but also ensures security in the future.