### PR TITLE
i18n: fix match links from `qsTr()`

### DIFF
--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -89,7 +89,7 @@ if (length(qmlFiles) == 0) {
       Line_number      = 1:nrow(readL),
       Translation_call = grepl(pattern = "qsTr(|Id|anslate)\\(['\"].*['\"]\\)", readL[, 1]),  # match for qsTr, qsTranslate and qsTrId calls.
       Empty_call       = grepl(pattern = "qsTr(|Id|anslate)\\((|['\"]['\"])\\)", readL[, 1]),  # match for empty qsTr(),qsTr(""),qsTr('') etc.
-      Link_embedded    = grepl(pattern = "(http|https)://", readL[, 1])
+      Link_embedded    = grepl(pattern = "(http|https)://", readL[, 1]) & !grepl(pattern = "arg\\([\"']?(http|https)://", readL[, 1])
     )
     
     qmlSrcData <- rbind(qmlSrcData, tempData)

--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -89,7 +89,7 @@ if (length(qmlFiles) == 0) {
       Line_number      = 1:nrow(readL),
       Translation_call = grepl(pattern = "qsTr(|Id|anslate)\\(['\"].*['\"]\\)", readL[, 1]),  # match for qsTr, qsTranslate and qsTrId calls.
       Empty_call       = grepl(pattern = "qsTr(|Id|anslate)\\((|['\"]['\"])\\)", readL[, 1]),  # match for empty qsTr(),qsTr(""),qsTr('') etc.
-      Link_embedded    = grepl(pattern = "(http|https)://", readL[, 1]) & !grepl(pattern = "arg\\([\"']?(http|https)://", readL[, 1])
+      Link_embedded    = grepl(pattern = "(http|https)://", readL[, 1]) & !grepl(pattern = "\\.arg\\([\"'].*(http|https)://", readL[, 1])
     )
     
     qmlSrcData <- rbind(qmlSrcData, tempData)


### PR DESCRIPTION
I forgot to exclude the link passed in the `.arg` already parameter...