### PR TITLE
unittest: remove igraph solution (#7)

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -154,12 +154,6 @@ jobs:
           jaspTools::setupJaspTools()
         shell: Rscript {0}
 
-      # so Rstudio's binary for igraph appears to be incompatible (i.e., crashes hard) with GitHub actions. Instead, we install igraph from source
-      - name: Make sure igraph is installed from source
-        if: runner.os == 'Linux' && inputs.needs_igraph
-        run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org/")
-        shell: Rscript {0}
-
       - name: Run unit tests
         run: source("tests/testthat.R")
         shell: Rscript {0}


### PR DESCRIPTION
igraph on Linux unittest now install within renv we cannot install out of project, otherwise it broken workflow.