### PR TITLE
use lockfiles for unit tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,29 +45,107 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install system dependencies on linux
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt install libharfbuzz-dev libfribidi-dev libgit2-dev libcurl4-openssl-dev libicu*
-        shell: bash
-
       - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+        # copied from https://github.com/r-lib/actions/blob/6b49fefb2846ed3e5e6e58366e7f7dfe01377f02/setup-r-dependencies/action.yaml#L67
+      - name: Set site library path
+        run: |
+          # Set site library path
+          cat("::group::Set site library path\n")
+          libpak <- Sys.getenv("R_LIB_FOR_PAK")
+          if (libpak != "") {
+            message("R_LIB_FOR_PAK is already set to ", libpak)
+          }
+          if (Sys.getenv("RENV_PROJECT") != "") {
+            message("renv project detected, no need to set R_LIBS_SITE")
+            if (libpak == "") {
+              cat(sprintf("R_LIB_FOR_PAK=%s\n", .libPaths()[1]), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+              message("Setting R_LIB_FOR_PAK to ", .libPaths()[1])
+            }
+            q("no")
+          }
+          lib <- Sys.getenv("R_LIBS_SITE")
+          if (lib == "") {
+            lib <- file.path(dirname(.Library), "site-library")
+            cat(sprintf("R_LIBS_SITE=%s\n", lib), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+            message("Setting R_LIBS_SITE to ", lib)
+            if (libpak == "") {
+              cat(sprintf("R_LIB_FOR_PAK=%s\n", lib), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+              message("Setting R_LIB_FOR_PAK to ", lib)
+            }
+          } else {
+            message("R_LIBS_SITE is already set to ", lib)
+            if (libpak == "") {
+              plib <- strsplit(lib, .Platform$path.sep)[[1]][[1]]
+              cat(sprintf("R_LIB_FOR_PAK=%s\n", plib), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+              message("Setting R_LIB_FOR_PAK to ", plib)
+            }
+          }
+          if (nchar("${{ env.R_LIBS_USER && 'ok' || '' }}") == 0) {
+            message("R_LIBS_USER GH env var is unset, setting now: ", Sys.getenv("R_LIBS_USER"))
+            cat(sprintf("R_LIBS_USER=%s\n", Sys.getenv("R_LIBS_USER")), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+          } else {
+            message("R_LIBS_USER GH env var is already set: ", Sys.getenv("R_LIBS_USER"))
+          }
+          dir.create(Sys.getenv("R_LIBS_SITE"), recursive = TRUE, showWarnings = FALSE)
+          dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE, showWarnings = FALSE)
+          cat("::endgroup::\n")
+        shell: Rscript {0}
+
+      - name: Install pak (Unix)
+        run: |
+          # Install pak
+          echo "::group::Install pak"
+          if which sudo >/dev/null; then SUDO="sudo -E --preserve-env=PATH env"; else SUDO=""; fi
+          $SUDO R -q -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), recursive = TRUE, showWarnings = FALSE)'
+          $SUDO R -q -e 'if (FALSE) { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK")) } else { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK"), repos = sprintf("https://r-lib.github.io/p/pak/%s/%s/%s/%s", "stable", .Platform$pkgType, R.Version()$os, R.Version()$arch)) }'
+          echo "::endgroup::"
+        shell: bash
+
+      - name: Install system dependencies on linux
+        run: |
+          install.packages("renv")
+          lib <- Sys.getenv("R_LIB_FOR_PAK")
+          lf <- renv::lockfile_read("renv.lock")
+          pkgs <- Filter(function(x) x$Source != "GitHub", lf$Packages)
+          pkgs2 <- unname(vapply(pkgs, FUN = `[[`, FUN.VALUE = character(1L), "Package"))
+          .libPaths(lib) # make sure pak is found
+          res <- pak::pkg_sysreqs(pkgs2, sysreqs_platform = "ubuntu")
+          cmd <- paste("sudo", res$install_scripts)
+          cat(sprintf("Running cmd:\n%s\n", cmd))
+          system(paste("sudo", res$install_scripts))
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/setup-renv@v2
         with:
-          extra-packages: |
-            any::covr
-            github::jasp-stats/jaspTools
-          needs: check
-          cache-version: 0
+          cache-version: 4
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+
+
+      - name: Install jaspTools if missing from lockfile
+        run: |
+          if (!require("jaspTools")) renv::install("jasp-stats/jaspTools")
+        shell: Rscript {0}
+
+      - name: Setup jaspTools
+        run: |
+          jaspTools::setupJaspTools()
+        shell: Rscript {0}
 
       - name: Install JAGS on Linux
-        if: runner.os == 'Linux' && inputs.needs_JAGS == true
+        if: inputs.needs_JAGS
         run: sudo apt install jags
         shell: bash
 
-      - name: Setup jaspTools
-        run: jaspTools::setupJaspTools()
+      - name: Install covr if missing from lockfile
+        run: |
+          if (!require("covr")) renv::install("covr")
         shell: Rscript {0}
 
       - name: Test coverage

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -80,7 +80,7 @@ jobs:
           brew install --cask xquartz
           brew install libarchive
           brew reinstall gettext
-          brew unlink gettext && brew link gettext --force
+          brew unlink gettext && brew link --force gettext
         shell: bash
 
       - name: Install system dependencies on macOS specific to R devel

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,9 +30,9 @@ jobs:
       name: Check for a scheduled run
       run: |
         if [ ${{ inputs.continue_on_schedule == 'true' || github.event_name != 'schedule' || github.repository_owner != 'jasp-stats' }} ]; then
-          echo "::set-output name=status::success"
+          echo "status=success" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=status::error"
+          echo "status=error" >> $GITHUB_OUTPUT
         fi
       shell: bash
 
@@ -78,7 +78,7 @@ jobs:
           unset HOMEBREW_NO_INSTALL_FROM_API
           brew update
           brew install --cask xquartz
-          brew install libarchive, gettext
+          brew install libarchive gettext
         shell: bash
 
       - name: Install system dependencies on macOS specific to R devel
@@ -127,10 +127,15 @@ jobs:
       - name: Install system dependencies on linux
         if: runner.os == 'Linux'
         run: |
-          sudo apt install libharfbuzz-dev libfribidi-dev \         # for ragg
-              libgit2-dev libcurl4-openssl-dev \                    # for credentials and curl, dependencies of usethis
-              libicu-dev \                                          # for igraph or stringi
-              libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev  # for cairo
+          # libharfbuzz-dev libfribidi-dev                         for ragg
+          # libgit2-dev libcurl4-openssl-dev                       for usethis
+          # libicu-dev                                             for igraph/stringi
+          # libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev   for cairo
+          sudo apt-get install -y \
+              libharfbuzz-dev libfribidi-dev \
+              libgit2-dev libcurl4-openssl-dev \
+              libicu-dev \
+              libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev
         shell: bash
 
       - name: Set environment variable to never compile packages on Windows and macOS

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -78,7 +78,9 @@ jobs:
           unset HOMEBREW_NO_INSTALL_FROM_API
           brew update
           brew install --cask xquartz
-          brew install libarchive gettext
+          brew install libarchive
+          brew reinstall gettext
+          brew unlink gettext && brew link gettext --force
         shell: bash
 
       - name: Install system dependencies on macOS specific to R devel
@@ -127,12 +129,12 @@ jobs:
       - name: Install system dependencies on linux
         if: runner.os == 'Linux'
         run: |
-          # libharfbuzz-dev libfribidi-dev                         for ragg
-          # libgit2-dev libcurl4-openssl-dev                       for usethis
-          # libicu-dev                                             for igraph/stringi
-          # libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev   for cairo
+          # ragg:           libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev
+          # usethis:        libgit2-dev libcurl4-openssl-dev
+          # igraph/stringi: libicu-dev
+          # cairo:          libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev
           sudo apt-get install -y \
-              libharfbuzz-dev libfribidi-dev \
+              libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev \
               libgit2-dev libcurl4-openssl-dev \
               libicu-dev \
               libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -42,7 +42,8 @@ jobs:
     if: needs.scheduled-run-check.outputs.status == 'success'
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} (R ${{ matrix.r }})
+    name: ${{ matrix.os }} (R ${{ matrix.r }} - ${{ matrix.packages }} packages)
+    continue-on-error: ${{ matrix.packages == 'latest' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -73,15 +73,9 @@ jobs:
 
       - name: Install system dependencies on macOS
         if: runner.os == 'macOS'
-        run: |
-          # see https://github.com/orgs/Homebrew/discussions/4612
-          unset HOMEBREW_NO_INSTALL_FROM_API
-          brew update
-          brew install --cask xquartz
-          brew install libarchive
-          brew reinstall gettext
-          brew unlink gettext && brew link --force gettext
-        shell: bash
+        uses: r-hub/actions/setup-r-sysreqs@v1
+        with:
+          type: full
 
       - name: Install system dependencies on macOS specific to R devel
         if: runner.os == 'macOS' && matrix.r == 'devel'

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -123,16 +123,22 @@ jobs:
       - name: Install system dependencies on linux
         if: runner.os == 'Linux'
         run: |
-          # ragg:           libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev
-          # usethis:        libgit2-dev libcurl4-openssl-dev
-          # igraph/stringi: libicu-dev
-          # cairo:          libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev
-          sudo apt-get install -y \
-              libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev \
-              libgit2-dev libcurl4-openssl-dev \
-              libicu-dev \
-              libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev
-        shell: bash
+          install.packages("renv")
+          install.packages("pak", lib = lib, repos = sprintf(
+              "https://r-lib.github.io/p/pak/%s/%s/%s/%s",
+              "stable",
+              .Platform$pkgType,
+              R.Version()$os,
+              R.Version()$arch
+            ))
+          lf <- renv::lockfile_read("renv.lock")
+          pkgs <- Filter(function(x) x$Source != "GitHub", lf$Packages)
+          pkgs2 <- unname(vapply(pkgs, FUN = `[[`, FUN.VALUE = character(1L), "Package"))
+          res <- pak::pkg_sysreqs(pkgs2, sysreqs_platform = "ubuntu")
+          cmd <- paste("sudo", res$install_scripts)
+          cat(sprintf("Running cmd:\n%s\n", cmd))
+          system(paste("sudo", res$install_scripts))
+        shell: Rscript {0}
 
       - name: Set environment variable to never compile packages on Windows and macOS
         if: runner.os != 'Linux' && matrix.r != 'devel'

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -121,19 +121,27 @@ jobs:
         shell: bash
 
       - name: Install system dependencies on linux
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.packages == 'lockfile'
         run: |
           install.packages("renv")
+          # put pak in a different library
+          lib <- Sys.getenv("R_LIBS_SITE")
+          if (lib == "") {
+            lib <- file.path(dirname(.Library), "site-library")
+            cat(sprintf("R_LIBS_SITE=%s\n", lib), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+            message("Setting R_LIBS_SITE to ", lib)
+          }
           install.packages("pak", lib = lib, repos = sprintf(
-              "https://r-lib.github.io/p/pak/%s/%s/%s/%s",
-              "stable",
-              .Platform$pkgType,
-              R.Version()$os,
-              R.Version()$arch
-            ))
+            "https://r-lib.github.io/p/pak/%s/%s/%s/%s",
+            "stable",
+            .Platform$pkgType,
+            R.Version()$os,
+            R.Version()$arch
+          ))
           lf <- renv::lockfile_read("renv.lock")
           pkgs <- Filter(function(x) x$Source != "GitHub", lf$Packages)
           pkgs2 <- unname(vapply(pkgs, FUN = `[[`, FUN.VALUE = character(1L), "Package"))
+          .libPaths(lib) # make sure pak is found
           res <- pak::pkg_sysreqs(pkgs2, sysreqs_platform = "ubuntu")
           cmd <- paste("sudo", res$install_scripts)
           cat(sprintf("Running cmd:\n%s\n", cmd))

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   scheduled-run-check:
-  
+
     runs-on: ubuntu-latest
     outputs:
       status: ${{ steps.check.outputs.status }}
@@ -37,18 +37,23 @@ jobs:
       shell: bash
 
   unit-tests:
-  
+
     needs: scheduled-run-check
     if: needs.scheduled-run-check.outputs.status == 'success'
-  
+
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (R ${{ matrix.r }})
 
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
         r: [release]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        packages: [lockfile]
+        include:
+        - os: ubuntu-latest
+          r: release
+          packages: latest
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -59,7 +64,7 @@ jobs:
       _R_CHECK_MATRIX_DATA_: TRUE # only works from R 4.2.0 onwards
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -74,7 +79,7 @@ jobs:
           brew install --cask xquartz
           brew install libarchive
         shell: bash
-        
+
       - name: Install system dependencies on macOS specific to R devel
         if: runner.os == 'macOS' && matrix.r == 'devel'
         run: |
@@ -82,35 +87,35 @@ jobs:
           # The dependencies of the two R packages below are required for compiling from source on Ubuntu, but macOS seems fine without them
           # credentials   (dependency of usethis)         requires libgit2
           # curl          (dependency of usethis)         requires openssl
-          
+
           brew install harfbuzz fribidi libgit2 openssl curl libpng
         shell: bash
 
       - name: Download JAGS and set JAGS_HOME on Windows
         if: runner.os == 'Windows' && inputs.needs_JAGS
-        run: |         
+        run: |
           beforeR420 <- getRversion() < "4.2.0"
-          
+
           jagsUrl <- if (beforeR420) {
             'https://static.jasp-stats.org/development/JAGS-4.3.0-Windows.zip'
           } else {
             'https://static.jasp-stats.org/development/JAGS-4.3.1-Windows.zip'
           }
-          
+
           destfile <- 'JAGS-Windows.zip'
           download.file(jagsUrl, destfile = destfile)
           unzip(destfile, exdir = 'JAGS')
-          
+
           con <- file(description = Sys.getenv("GITHUB_ENV"), open = "a")
           on.exit(close(con))
-          
+
           jagsHome <- jagsRoot <- normalizePath("JAGS", winslash = "/")
           cat("JAGS_HOME=", jagsHome, "\n", sep = "", file = con)
-          cat("JAGS_ROOT=", jagsRoot, "\n", sep = "", file = con)         
-          
+          cat("JAGS_ROOT=", jagsRoot, "\n", sep = "", file = con)
+
         working-directory: ..
         shell: Rscript {0}
-        
+
       - name: Install JAGS on macOS
         if: runner.os == 'macOS' && inputs.needs_JAGS
         run: |
@@ -121,7 +126,7 @@ jobs:
       - name: Install system dependencies on linux
         if: runner.os == 'Linux'
         run: |
-          # ragg                                          requires libharfbuzz-dev libfribidi-dev 
+          # ragg                                          requires libharfbuzz-dev libfribidi-dev
           # credentials   (dependency of usethis)         requires libgit2-dev
           # curl          (dependency of usethis)         requires libcurl4-openssl-dev
           # libicu   (dependency of igraph or stringi...) requires libicu libicu-dev
@@ -135,8 +140,14 @@ jobs:
           # don't try to install new pkgs versions from source (which often requires additional system dependencies which, when missing, lead to errors, e.g., ragg).
           cat("\noptions(install.packages.compile.from.source = \"never\")\n", file = "~/.Rprofile", sep = "", append = TRUE)
         shell: Rscript {0}
-        
+
+      - uses: r-lib/actions/setup-renv@v2
+        if: matrix.packages == 'lockfile'
+        with:
+          cache-version: 4
+
       - uses: r-lib/actions/setup-r-dependencies@v2
+        if: matrix.packages == 'latest'
         with:
           extra-packages: |
             any::rcmdcheck

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -78,7 +78,7 @@ jobs:
           unset HOMEBREW_NO_INSTALL_FROM_API
           brew update
           brew install --cask xquartz
-          brew install libarchive
+          brew install libarchive, gettext
         shell: bash
 
       - name: Install system dependencies on macOS specific to R devel
@@ -127,12 +127,10 @@ jobs:
       - name: Install system dependencies on linux
         if: runner.os == 'Linux'
         run: |
-          # ragg                                          requires libharfbuzz-dev libfribidi-dev
-          # credentials   (dependency of usethis)         requires libgit2-dev
-          # curl          (dependency of usethis)         requires libcurl4-openssl-dev
-          # libicu   (dependency of igraph or stringi...) requires libicu libicu-dev
-
-          sudo apt install libharfbuzz-dev libfribidi-dev libgit2-dev libcurl4-openssl-dev libicu*
+          sudo apt install libharfbuzz-dev libfribidi-dev \         # for ragg
+              libgit2-dev libcurl4-openssl-dev \                    # for credentials and curl, dependencies of usethis
+              libicu-dev \                                          # for igraph or stringi
+              libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev  # for cairo
         shell: bash
 
       - name: Set environment variable to never compile packages on Windows and macOS
@@ -146,6 +144,12 @@ jobs:
         if: matrix.packages == 'lockfile'
         with:
           cache-version: 4
+
+      - name: Install jaspTools if missing from lockfile
+        if: matrix.packages == 'lockfile'
+        run: |
+          if (!require("jaspTools")) renv::install("jasp-stats/jaspTools")
+        shell: Rscript {0}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         if: matrix.packages == 'latest'
@@ -164,12 +168,6 @@ jobs:
       - name: Setup jaspTools
         run: |
           jaspTools::setupJaspTools()
-        shell: Rscript {0}
-
-      # so Rstudio's binary for igraph appears to be incompatible (i.e., crashes hard) with GitHub actions. Instead, we install igraph from source
-      - name: Make sure igraph is installed from source
-        if: runner.os == 'Linux' && inputs.needs_igraph
-        run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org/")
         shell: Rscript {0}
 
       - name: Run unit tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -120,24 +120,68 @@ jobs:
           brew install jags
         shell: bash
 
-      - name: Install system dependencies on linux
+        # copied from https://github.com/r-lib/actions/blob/6b49fefb2846ed3e5e6e58366e7f7dfe01377f02/setup-r-dependencies/action.yaml#L67
+      - name: Set site library path
         if: runner.os == 'Linux' && matrix.packages == 'lockfile'
         run: |
-          install.packages("renv")
-          # put pak in a different library
+          # Set site library path
+          cat("::group::Set site library path\n")
+          libpak <- Sys.getenv("R_LIB_FOR_PAK")
+          if (libpak != "") {
+            message("R_LIB_FOR_PAK is already set to ", libpak)
+          }
+          if (Sys.getenv("RENV_PROJECT") != "") {
+            message("renv project detected, no need to set R_LIBS_SITE")
+            if (libpak == "") {
+              cat(sprintf("R_LIB_FOR_PAK=%s\n", .libPaths()[1]), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+              message("Setting R_LIB_FOR_PAK to ", .libPaths()[1])
+            }
+            q("no")
+          }
           lib <- Sys.getenv("R_LIBS_SITE")
           if (lib == "") {
             lib <- file.path(dirname(.Library), "site-library")
             cat(sprintf("R_LIBS_SITE=%s\n", lib), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
             message("Setting R_LIBS_SITE to ", lib)
+            if (libpak == "") {
+              cat(sprintf("R_LIB_FOR_PAK=%s\n", lib), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+              message("Setting R_LIB_FOR_PAK to ", lib)
+            }
+          } else {
+            message("R_LIBS_SITE is already set to ", lib)
+            if (libpak == "") {
+              plib <- strsplit(lib, .Platform$path.sep)[[1]][[1]]
+              cat(sprintf("R_LIB_FOR_PAK=%s\n", plib), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+              message("Setting R_LIB_FOR_PAK to ", plib)
+            }
           }
-          install.packages("pak", lib = lib, repos = sprintf(
-            "https://r-lib.github.io/p/pak/%s/%s/%s/%s",
-            "stable",
-            .Platform$pkgType,
-            R.Version()$os,
-            R.Version()$arch
-          ))
+          if (nchar("${{ env.R_LIBS_USER && 'ok' || '' }}") == 0) {
+            message("R_LIBS_USER GH env var is unset, setting now: ", Sys.getenv("R_LIBS_USER"))
+            cat(sprintf("R_LIBS_USER=%s\n", Sys.getenv("R_LIBS_USER")), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+          } else {
+            message("R_LIBS_USER GH env var is already set: ", Sys.getenv("R_LIBS_USER"))
+          }
+          dir.create(Sys.getenv("R_LIBS_SITE"), recursive = TRUE, showWarnings = FALSE)
+          dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE, showWarnings = FALSE)
+          cat("::endgroup::\n")
+        shell: Rscript {0}
+
+      - name: Install pak (Unix)
+        if: runner.os == 'Linux' && matrix.packages == 'lockfile'
+        run: |
+          # Install pak
+          echo "::group::Install pak"
+          if which sudo >/dev/null; then SUDO="sudo -E --preserve-env=PATH env"; else SUDO=""; fi
+          $SUDO R -q -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), recursive = TRUE, showWarnings = FALSE)'
+          $SUDO R -q -e 'if (false) { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK")) } else { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK"), repos = sprintf("https://r-lib.github.io/p/pak/%s/%s/%s/%s", "stable", .Platform$pkgType, R.Version()$os, R.Version()$arch)) }'
+          echo "::endgroup::"
+        shell: bash
+
+      - name: Install system dependencies on linux
+        if: runner.os == 'Linux' && matrix.packages == 'lockfile'
+        run: |
+          install.packages("renv")
+          lib <- Sys.getenv("R_LIB_FOR_PAK")
           lf <- renv::lockfile_read("renv.lock")
           pkgs <- Filter(function(x) x$Source != "GitHub", lf$Packages)
           pkgs2 <- unname(vapply(pkgs, FUN = `[[`, FUN.VALUE = character(1L), "Package"))
@@ -146,13 +190,6 @@ jobs:
           cmd <- paste("sudo", res$install_scripts)
           cat(sprintf("Running cmd:\n%s\n", cmd))
           system(paste("sudo", res$install_scripts))
-        shell: Rscript {0}
-
-      - name: Set environment variable to never compile packages on Windows and macOS
-        if: runner.os != 'Linux' && matrix.r != 'devel'
-        run: |
-          # don't try to install new pkgs versions from source (which often requires additional system dependencies which, when missing, lead to errors, e.g., ragg).
-          cat("\noptions(install.packages.compile.from.source = \"never\")\n", file = "~/.Rprofile", sep = "", append = TRUE)
         shell: Rscript {0}
 
       - uses: r-lib/actions/setup-renv@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -173,7 +173,7 @@ jobs:
           echo "::group::Install pak"
           if which sudo >/dev/null; then SUDO="sudo -E --preserve-env=PATH env"; else SUDO=""; fi
           $SUDO R -q -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), recursive = TRUE, showWarnings = FALSE)'
-          $SUDO R -q -e 'if (false) { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK")) } else { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK"), repos = sprintf("https://r-lib.github.io/p/pak/%s/%s/%s/%s", "stable", .Platform$pkgType, R.Version()$os, R.Version()$arch)) }'
+          $SUDO R -q -e 'if (FALSE) { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK")) } else { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK"), repos = sprintf("https://r-lib.github.io/p/pak/%s/%s/%s/%s", "stable", .Platform$pkgType, R.Version()$os, R.Version()$arch)) }'
           echo "::endgroup::"
         shell: bash
 


### PR DESCRIPTION
unit tests with lockfiles are run for windows, macOs, and Linux
unit tests with latest package versions are run on Linux.
The idea is that the run with the latest package versions is allowed to fail.

example run: https://github.com/vandenman/jaspDescriptives/actions/runs/17776414733/job/50525620971