### PR TITLE
Fix jags & rjags on macos

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -120,11 +120,16 @@ jobs:
           brew install jags
           brew info jags
           # Figure out where Homebrew installed JAGS
+          # on arm this is a different location than what the rjags binary expects
           JAGS_PREFIX=$(brew --prefix jags)
           echo "JAGS installed at: $JAGS_PREFIX"
           # Create /usr/local/lib if needed and link the dylibs
           sudo mkdir -p /usr/local/lib
           sudo ln -sf "${JAGS_PREFIX}/lib/libjags."*.dylib /usr/local/lib/
+          # move the modules folder (basemod, etc.) as well
+          if [ -d "${JAGS_PREFIX}/lib/JAGS" ]; then
+            sudo ln -sfn "${JAGS_PREFIX}/lib/JAGS" /usr/local/lib/JAGS
+          fi
           # Optional check
           ls -l /usr/local/lib/libjags*.dylib
         shell: bash


### PR DESCRIPTION
Chatgpt inspired fix for jags/ rjags on macos. Basically, we errors of the form:

```
error: .onLoad failed in loadNamespace() for 'rjags', details:
  call: dyn.load(file, DLLpath = DLLpath, ...)
  error: unable to load shared object '/Users/runner/work/_temp/renv/cache/v5/macos/R-4.5/aarch64-apple-darwin20/rjags/4-17/1cf40ca3e11ef31ed51be85d4d227d8d/rjags/libs/rjags.so':
  dlopen(/Users/runner/work/_temp/renv/cache/v5/macos/R-4.5/aarch64-apple-darwin20/rjags/4-17/1cf40ca3e11ef31ed51be85d4d227d8d/rjags/libs/rjags.so, 0x000A): Library not loaded: /usr/local/lib/libjags.4.dylib
```

This error is likely caused by either 1) homebrew installing jags in a different location on arm64 macos (deriving arm from aarch64 in the path here) compared to intel, or 2) the rjags binary looking in a different location.

The fix is to symlink both jags and the modules directory to the location that rjags expects. I'm not sure if this is future proof, but for now it appear to works. I've left a few debug prints in for when this inevitably breaks in the future.