### PR TITLE
i18n: check space in msgstr from the QML PO files

### DIFF
--- a/translations/i18nCheck.R
+++ b/translations/i18nCheck.R
@@ -4,16 +4,23 @@
 library(potools)
 library(cli)
 
-checkStatus <- c()
+# Global check flags
+rFailed   <- FALSE
+qmlFailed <- FALSE
 
-msgErrorCheck <- function(msgData, warningMsg) {
+rMsgErrorCheck <- function(msgData, warningMsg) {
   if (nrow(msgData) > 0) {
-    checkStatus <<- c(checkStatus, 1)
+    rFailed <<- TRUE
     cli_h2("Please refer to following to resolve them:")
     cli_alert_danger(warningMsg)
     print(msgData, row.names = FALSE)
   }
 }
+
+# ---------------------------
+# R level translation check
+# ---------------------------
+
 # Generate pot meta data from .R
 cli_h1("Check R translations:")
 rPotData <- potools::get_message_data(dir = ".", verbose = TRUE)
@@ -34,11 +41,11 @@ rErrorCalls <- subset(rPotData,
                       grepl(pattern = "^gettext\\(.*%.*\\)", call),   # match single % inside gettext()
                       select = c("file", "call", "line_number"))
 rLinkEmbedded <- subset(rPotData,
-                      grepl(pattern = "(http|https)://", msgid),
-                      select = c("file", "call", "line_number"))
+                        grepl(pattern = "(http|https)://", msgid),
+                        select = c("file", "call", "line_number"))
 
 # Get po/mo compiling error of R, We customized the tools::checkPoFiles function
-jaspCheckPoFiles <- function(dir) {
+checkRPoFiles <- function(dir) {
   files <- list.files(path = dir, pattern = "^R-.*[.]po$",
                       full.names = TRUE, recursive = TRUE)
   result <- matrix(character(), ncol = 5L, nrow = 0L)
@@ -50,7 +57,7 @@ jaspCheckPoFiles <- function(dir) {
   return(result)
 }
 
-e <- jaspCheckPoFiles("./po")
+e <- checkRPoFiles("./po")
 
 rPoError <- data.frame()
 if (length(e) > 1) {
@@ -58,32 +65,38 @@ if (length(e) > 1) {
   colnames(rPoError) <- c("Error_Location", "References", "Error_Type", "Original_Gettext", "Translated_text")
 }
 
-msgErrorCheck(rPoError,         "Some translation errors found in po file.")
-msgErrorCheck(rEmptyCalls,      "{nrow(rEmptyCalls)} empty gettext call(s) found.")
-msgErrorCheck(placeholderData,  "{nrow(placeholderData)} multiple placeholders without index found.")
-msgErrorCheck(templateMsgError, "There are numbering errors with multiple placeholders.")
-msgErrorCheck(rErrorCalls,      "Don't use `gettext()` if `%` inside, but use `gettextf()` with `%%` instead.")
-msgErrorCheck(rLinkEmbedded,    "Please don't pass the link directly inside translation call(s).")
+rMsgErrorCheck(rPoError,         "Some translation errors found in po file.")
+rMsgErrorCheck(rEmptyCalls,      "{nrow(rEmptyCalls)} empty gettext call(s) found.")
+rMsgErrorCheck(placeholderData,  "{nrow(placeholderData)} multiple placeholders without index found.")
+rMsgErrorCheck(templateMsgError, "There are numbering errors with multiple placeholders.")
+rMsgErrorCheck(rErrorCalls,      "Don't use `gettext()` if `%` inside, but use `gettextf()` with `%%` instead.")
+rMsgErrorCheck(rLinkEmbedded,    "Please don't pass the link directly inside translation call(s).")
 
-if (length(checkStatus) == 0) {
+if (!rFailed) {
   cli_alert_success("R message check PASSED")
 }
 
+# ---------------------------
+# QML level translation check
+# ---------------------------
+
 cli_h1("Check QML translations:")
 # Get QML files paths
-qmlFiles <- list.files(path = file.path("inst", "qml"), pattern = "\\.qml", recursive = TRUE, full.names = TRUE)
+qmlSrcFiles <- list.files(path = file.path("inst", "qml"), pattern = "\\.qml", recursive = TRUE, full.names = TRUE)
+qmlPoFiles <- list.files(path = "po", pattern = "^QML-.*[.]po$",
+                                    full.names = TRUE, recursive = TRUE)
 
-if (length(qmlFiles) == 0) {
+if (length(qmlSrcFiles) == 0) {
   cli_alert("No QML file found, maybe it's not a valid JASP module.")
 } else {
   # Generate pot meta data from QML
   qmlSrcData <- data.frame()
   message("Getting QML-level messages...")
   
-  for (i in 1:length(qmlFiles)) {
-    filePaths <- paste0("./", qmlFiles[i])
+  for (i in 1:length(qmlSrcFiles)) {
+    filePaths <- paste0("./", qmlSrcFiles[i])
     readL <- as.data.frame(readLines(filePaths, warn = FALSE))
-    tempData <- data.frame(
+    tempSrcData <- data.frame(
       Source_file      = rep(filePaths),
       Call_code        = readL[, 1],
       Line_number      = 1:nrow(readL),
@@ -92,23 +105,48 @@ if (length(qmlFiles) == 0) {
       Link_embedded    = grepl(pattern = "(http|https)://", readL[, 1]) & !grepl(pattern = "\\.arg\\([\"'].*(http|https)://", readL[, 1])
     )
     
-    qmlSrcData <- rbind(qmlSrcData, tempData)
+    qmlSrcData <- rbind(qmlSrcData, tempSrcData)
+  }
+  
+  
+  qmlPoMsgstr <- data.frame()
+  
+  for (i in 1:length(qmlPoFiles)) {
+    pofilePaths <- paste0("./", qmlPoFiles[i])
+    readPo <- as.data.frame(readLines(pofilePaths, warn = FALSE))
+    tempPoData <- data.frame(
+      Source_file      = rep(pofilePaths),
+      Line_number      = 1:nrow(readPo),
+      Empty_Msgstr = grepl(pattern = "^msgstr\\s+\"\\s+\"\\s*$", readPo[, 1])
+    )
+    
+    qmlPoMsgstr <- rbind(qmlPoMsgstr, tempPoData)
   }
   
   hasEmptyCall  <- qmlSrcData$Empty_call == TRUE
   hasLink       <- qmlSrcData$Translation_call & qmlSrcData$Link_embedded
   qmlErrorCalls <- subset(qmlSrcData, hasEmptyCall | hasLink, select = c(1:3))
   
-  if (nrow(qmlErrorCalls) == 0) {
-    cli_alert_success("QML message check PASSED")
-  } else {
+  if (nrow(qmlErrorCalls) != 0) {
+    cli_h2("{nrow(qmlErrorCalls)} not recommended Qt translate call(s) found.")
     if (any(hasEmptyCall))    cli_alert_danger("Please don't pass empty strings inside translation call(s).")
     if (any(hasLink))         cli_alert_danger("Please use `.arg()` to pass the link instead of pass it directly inside call(s).")
-    msgErrorCheck(qmlErrorCalls, "{nrow(qmlErrorCalls)} not recommended Qt translate call(s) found.")
+    print(qmlErrorCalls, row.names = FALSE)
+  }
+  
+  if (any(qmlPoMsgstr$Empty_Msgstr == TRUE)) {
+    qmlFailed <<- TRUE
+    cli_h2("There are some incorrect translations (probably caused by the translator) detected:")
+    cli_alert_danger("msgstr contains only invisible characters such as spaces or tabs in the PO file(s), please remove them.")
+    print(subset(qmlPoMsgstr, qmlPoMsgstr$Empty_Msgstr == TRUE), row.names = FALSE)
+  }
+  
+  if (!qmlFailed) {
+    cli_alert_success("QML message check PASSED")
   }
 }
 
-if (length(checkStatus) > 0) {
+if (rFailed || qmlFailed) {
   # failing github action,custom exit code to different from a system exit
   quit(status = 10)
 } else {


### PR DESCRIPTION
If you look at https://github.com/jasp-stats/jaspFactor/blob/master/inst/qml/translations/jaspFactor-es.qm the translation had not be updated for 3 years! which is because there are QML lrelease error at https://github.com/jasp-stats/jaspFactor/actions/runs/18797603545/job/53640326727#step:3:2634 says:`Unexpected PO header format '  '` , it is because in the QML-es.po file https://github.com/jasp-stats/jaspFactor/blob/d21ad46ee61ada62394958a973f2f3a4dd8eb72f/po/QML-es.po#L591 this msgstr only contains space character, so .qm file not be compiled.


Now we can run this check all po files and change them,then I expect we'll see a lot of translations updated!