### PR TITLE
add condition to skip translate PRs in workflow

### DIFF
--- a/.github/workflows/remind-news.yml
+++ b/.github/workflows/remind-news.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   remind-news:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'weblate'   # Don't work on translate PR.
     permissions:
       pull-requests: write # Required so the bot can leave a comment
     steps:


### PR DESCRIPTION
News reminder should not work on translate PR.Otherwise, contributors will receive meaningless notifications.