### PR TITLE
Align coverage dependency restore with unit tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,6 +39,12 @@ jobs:
       R_REMOTES_UPGRADE: never
       VDIFFR_RUN_TESTS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RENV_CONFIG_INSTALL_JOBS: 1
+      RENV_CONFIG_INSTALL_STAGED: false
+      RENV_CONFIG_REPOS_OVERRIDE: https://packagemanager.posit.co/cran/latest
+      RENV_CONFIG_PAK_ENABLED: true
+      PKG_BUILD_CORES: 1
+      PAK_CORES: 1
       _R_CHECK_LENGTH_1_CONDITION_: TRUE # deprecated from R 4.2.0
       _R_CHECK_MATRIX_DATA_: TRUE        # only works from R 4.2.0 onwards
 
@@ -46,6 +52,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.5.2'
+          Ncpus: 1
 
         # copied from https://github.com/r-lib/actions/blob/6b49fefb2846ed3e5e6e58366e7f7dfe01377f02/setup-r-dependencies/action.yaml#L67
       - name: Set site library path
@@ -107,6 +116,7 @@ jobs:
         shell: bash
         run: |
           echo "RENV_PATHS_ROOT=${{ runner.temp }}/renv" >> $GITHUB_ENV
+          echo "R_PKG_CACHE_DIR=${{ runner.temp }}/pkgcache" >> $GITHUB_ENV
 
       - name: Install system dependencies on linux
         run: |
@@ -137,7 +147,7 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
         with:
-          cache-version: 4
+          cache-version: 6
 
       - name: Install jaspTools if missing from lockfile
         run: |


### PR DESCRIPTION
## Summary
- add the same renv/pak install controls to the coverage workflow that are already used by the lockfile unit-test workflow
- pin coverage to R 4.5.2 with single-core package builds
- isolate the pak/pkgcache directory under the runner temp directory
- bump the coverage renv cache version so old restore caches are not reused

## Why
The coverage workflow currently restores lockfile dependencies with a different setup than the stable unit-test workflow. This showed up in `jaspSurvival` PR CI, where `coverage / coverage` failed during `r-lib/actions/setup-renv@v2` while installing `jaspTools`:

> there is no package called 'rlang'

The matching unit-test lockfile job succeeded on the same commit. The relevant difference is that unit tests already serialize renv/pak/package builds, disable staged installs, pin R to 4.5.2, and isolate the package cache. Coverage did not use those safeguards.

That matters when a lockfile contains source/GitHub dependencies, e.g. a development `rlang`. A parallel or staged restore can attempt to lazy-load `jaspTools` or its imports before `rlang` is visible in the active library. Aligning coverage with the unit-test restore path makes the two CI jobs behave consistently and reduces these dependency-order failures.

## Validation
- `git diff --check`